### PR TITLE
Add preset worktree command with resolvePrompts tests

### DIFF
--- a/.claude/extensions/worktree-setup/index.ts
+++ b/.claude/extensions/worktree-setup/index.ts
@@ -1,0 +1,24 @@
+import { defineExtension } from "@dawkinsuke/hooks"
+import { existsSync } from "node:fs"
+
+export default defineExtension((cc) => {
+	cc.on("WorktreeCreate", async (input) => {
+		const root = input.cwd
+		const name = input.name
+		const worktreeDir = `${root}/.worktrees/${name}`
+
+		// Reuse existing worktree if it exists
+		if (existsSync(worktreeDir)) return worktreeDir
+
+		// Create worktree with new branch
+		await Bun.$`git worktree add -b ${name} ${worktreeDir} 1>&2`
+
+		// .envrc is gitignored; share direnv config from project root
+		await Bun.$`ln -sf "${root}/.envrc" "${worktreeDir}/.envrc" 1>&2`
+
+		// Install deps and run prepare (lefthook install)
+		await Bun.$`cd ${worktreeDir} && bun install 1>&2`
+
+		return worktreeDir
+	})
+})

--- a/.claude/hooks/.manifest.json
+++ b/.claude/hooks/.manifest.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generatedAt": "2026-03-21T05:12:36.024Z",
+	"generatedAt": "2026-03-23T14:00:56.816Z",
 	"extensions": {
 		"readme-check": {
 			"enabled": true,
@@ -8,6 +8,15 @@
 				{
 					"type": "command",
 					"event": "PreToolUse"
+				}
+			]
+		},
+		"worktree-setup": {
+			"enabled": true,
+			"registrations": [
+				{
+					"type": "command",
+					"event": "WorktreeCreate"
 				}
 			]
 		},

--- a/.claude/hooks/worktree-setup.mjs
+++ b/.claude/hooks/worktree-setup.mjs
@@ -1,0 +1,108 @@
+// src/api/output.ts
+var HOOK_OUTPUT_MARKER = Symbol.for("hx:HookOutput");
+function isHookOutput(value) {
+  return typeof value === "object" && value !== null && HOOK_OUTPUT_MARKER in value;
+}
+
+// src/runtime.ts
+class HookBlockError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "HookBlockError";
+  }
+}
+async function runHook(factory) {
+  const targetEvent = process.argv[2];
+  const targetMatcher = process.argv[3] || undefined;
+  if (!targetEvent) {
+    process.stderr.write(`Usage: <script> <event> [matcher]
+`);
+    process.exit(1);
+  }
+  const handlers = [];
+  const api = {
+    on(event, ...args) {
+      let matcher;
+      let handler;
+      if (args.length >= 2 && typeof args[0] === "string") {
+        matcher = args[0];
+        handler = args[1];
+      } else if (args.length >= 2 && typeof args[0] === "object" && args[0] !== null) {
+        const opts = args[0];
+        matcher = opts.matcher;
+        handler = args[1];
+      } else {
+        handler = args[0];
+      }
+      if (event === targetEvent && matcher === targetMatcher) {
+        handlers.push(handler);
+      }
+    },
+    http() {},
+    prompt() {},
+    agent() {}
+  };
+  await factory(api);
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+  const input = raw ? JSON.parse(raw) : {};
+  let result;
+  try {
+    for (const handler of handlers) {
+      const r = await handler(input);
+      if (r !== undefined && r !== null) {
+        result = r;
+      }
+    }
+  } catch (err) {
+    if (err instanceof HookBlockError) {
+      process.stderr.write(err.message);
+      process.exit(2);
+    }
+    throw err;
+  }
+  if (result === undefined || result === null) {
+    return;
+  }
+  if (typeof result === "string") {
+    process.stdout.write(result);
+  } else if (isHookOutput(result)) {
+    if (result._visible && result._context) {
+      try {
+        const msg = result._context.replaceAll('"', "\\\"");
+        const script = `display notification "${msg}" with title "hx"`;
+        await Bun.$`osascript -e ${script}`.quiet();
+      } catch {}
+    }
+    const resolved = result._resolve(targetEvent);
+    process.stdout.write(JSON.stringify(resolved));
+  } else {
+    process.stdout.write(JSON.stringify(result));
+  }
+}
+
+// src/api/extension-api.ts
+function defineExtension(factory) {
+  return factory;
+}
+// .claude/extensions/worktree-setup/index.ts
+import { existsSync } from "node:fs";
+var worktree_setup_default = defineExtension((cc) => {
+  cc.on("WorktreeCreate", async (input) => {
+    const root = input.cwd;
+    const name = input.name;
+    const worktreeDir = `${root}/.worktrees/${name}`;
+    if (existsSync(worktreeDir))
+      return worktreeDir;
+    await Bun.$`git worktree add -b ${name} ${worktreeDir} 1>&2`;
+    await Bun.$`ln -sf "${root}/.envrc" "${worktreeDir}/.envrc" 1>&2`;
+    await Bun.$`cd ${worktreeDir} && bun install 1>&2`;
+    return worktreeDir;
+  });
+});
+
+// hx-virtual:hx-virtual:worktree-setup.mjs
+await runHook(worktree_setup_default);

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 dist/
 docs/memory/
 skills/hook-creator-workspace/
+.envrc

--- a/docs/sources.json
+++ b/docs/sources.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-03-20T21:03:39.196Z",
+  "updatedAt": "2026-03-23T12:54:11.627Z",
   "repos": [
     {
       "name": "github.com/badlogic/pi-mono",
@@ -12,6 +12,12 @@
       "version": "main",
       "path": "repos/github.com/anthropics/claude-agent-sdk-typescript",
       "fetchedAt": "2026-03-20T21:03:39.196Z"
+    },
+    {
+      "name": "github.com/craigsc/cmux",
+      "version": "main",
+      "path": "repos/github.com/craigsc/cmux",
+      "fetchedAt": "2026-03-23T12:54:11.627Z"
     }
   ]
 }

--- a/src/cli/commands/preset.ts
+++ b/src/cli/commands/preset.ts
@@ -1,0 +1,8 @@
+import { defineGroup } from "@bunli/core"
+import worktreeCommand from "./preset/worktree.js"
+
+export default defineGroup({
+	name: "preset",
+	description: "Scaffold pre-built extension templates",
+	commands: [worktreeCommand],
+})

--- a/src/cli/commands/preset/worktree.ts
+++ b/src/cli/commands/preset/worktree.ts
@@ -1,0 +1,230 @@
+import { defineCommand, option } from "@bunli/core"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { z } from "zod"
+import { buildExtensions } from "../../../build/builder.js"
+
+export const SYSTEM_PROMPT = `You generate TypeScript extension files for hx-cli (Claude Code hooks toolkit).
+Output ONLY the TypeScript code — no markdown fences, no prose, no explanation.
+The first line of your response must be: import { defineExtension } from "@dawkinsuke/hooks";
+Do not wrap the code in \`\`\` code blocks.`
+
+export const EDIT_SYSTEM_PROMPT = `You modify TypeScript extension files for hx-cli (Claude Code hooks toolkit).
+You will receive a modification request for an existing extension file.
+Output ONLY the modified TypeScript code — no markdown fences, no prose, no explanation.
+The first line of your response must be: import { defineExtension } from "@dawkinsuke/hooks";
+Do not wrap the code in \`\`\` code blocks.`
+
+export const PROMPT = `Generate a WorktreeCreate extension for this repo.
+
+WorktreeCreate is responsible for CREATING a git worktree and returning its absolute path.
+Claude Code uses the returned path as the working directory for the isolated session.
+If no path is returned, worktree creation FAILS.
+WorktreeRemove is NOT needed — Claude Code handles default git worktree removal automatically.
+
+Rules:
+- Start with: import { defineExtension } from "@dawkinsuke/hooks";
+- Use cc.on("WorktreeCreate", async (input) => { ... })
+- input.cwd is the project root directory
+- input.name is the worktree name/slug
+- Use Bun.$\`... 1>&2\` for shell commands (stdout is reserved for the worktree path, so redirect command output to stderr)
+- WorktreeCreate MUST return the absolute path string of the created worktree
+- Create the worktree under \`\${input.cwd}/.worktrees/\${input.name}\`
+- Be idempotent: use existsSync from "node:fs" to check if the worktree directory already exists, and if so skip creation and return the path immediately
+- Create a new branch with the same name as input.name
+- After creating the worktree, symlink any gitignored secret/config files from input.cwd
+- Install dependencies if a lock file exists (detect package manager)
+- Run codegen/build steps if applicable
+- Only include setup steps relevant to THIS repo — omit anything that doesn't apply
+- Use short comments for non-obvious lines
+- No console.log — use console.error for diagnostics (stdout is reserved for the worktree path return value)
+- If the repo needs no post-creation setup, just create the worktree and return the path
+- Do NOT add a WorktreeRemove handler — Claude Code's default git worktree removal handles cleanup automatically. A custom handler is only needed for non-git VCS (SVN, Perforce, etc.)
+
+Example output for a Node.js project:
+
+import { defineExtension } from "@dawkinsuke/hooks";
+import { existsSync } from "node:fs";
+
+export default defineExtension((cc) => {
+\tcc.on("WorktreeCreate", async (input) => {
+\t\tconst root = input.cwd;
+\t\tconst name = input.name;
+\t\tconst worktreeDir = \`\${root}/.worktrees/\${name}\`;
+
+\t\t// Reuse existing worktree if it exists
+\t\tif (existsSync(worktreeDir)) return worktreeDir;
+
+\t\t// Create worktree with new branch
+\t\tawait Bun.$\`git worktree add -b \${name} \${worktreeDir}\` 1>&2;
+
+\t\t// Symlink secrets from project root
+\t\tawait Bun.$\`ln -sf "\${root}/.env" "\${worktreeDir}/.env"\` 1>&2;
+\t\tawait Bun.$\`ln -sf "\${root}/.dev.vars" "\${worktreeDir}/.dev.vars"\` 1>&2;
+
+\t\t// Install deps and run codegen
+\t\tawait Bun.$\`cd \${worktreeDir} && npm ci && npx prisma generate\` 1>&2;
+
+\t\treturn worktreeDir;
+\t});
+});
+
+Example output for a Rust project:
+
+import { defineExtension } from "@dawkinsuke/hooks";
+import { existsSync } from "node:fs";
+
+export default defineExtension((cc) => {
+\tcc.on("WorktreeCreate", async (input) => {
+\t\tconst root = input.cwd;
+\t\tconst name = input.name;
+\t\tconst worktreeDir = \`\${root}/.worktrees/\${name}\`;
+
+\t\tif (existsSync(worktreeDir)) return worktreeDir;
+
+\t\tawait Bun.$\`git worktree add -b \${name} \${worktreeDir}\` 1>&2;
+\t\tawait Bun.$\`ln -sf "\${root}/.env" "\${worktreeDir}/.env"\` 1>&2;
+\t\tawait Bun.$\`cd \${worktreeDir} && cargo fetch\` 1>&2;
+
+\t\treturn worktreeDir;
+\t});
+});
+
+IMPORTANT: Output ONLY the raw TypeScript code. The very first characters of
+your response must be: import { defineExtension } — no preamble, no markdown,
+no commentary.`
+
+// ---------------------------------------------------------------------------
+// Prompt resolution — determines which system prompt & user prompt to use
+// ---------------------------------------------------------------------------
+
+export type PromptResolution =
+	| { kind: "generate"; systemPrompt: string; prompt: string }
+	| { kind: "error"; message: string }
+
+export function resolvePrompts(
+	flags: { replace: boolean; edit?: string },
+	extensionExists: boolean,
+): PromptResolution {
+	// --edit: modify existing extension
+	if (flags.edit) {
+		if (!extensionExists) {
+			return {
+				kind: "error",
+				message: "No existing extension found. Run 'hx preset worktree' first.",
+			}
+		}
+
+		const editPrompt = `Read .claude/extensions/worktree-setup/index.ts and modify it based on:
+${flags.edit}
+
+Output the complete updated extension.
+Keep all existing logic intact unless the modification explicitly changes it.`
+
+		return { kind: "generate", systemPrompt: EDIT_SYSTEM_PROMPT, prompt: editPrompt }
+	}
+
+	// --replace or new: generate from scratch
+	if (extensionExists && !flags.replace) {
+		return {
+			kind: "error",
+			message:
+				'Extension "worktree-setup" already exists at .claude/extensions/worktree-setup/\n' +
+				"Run 'hx preset worktree --replace' to regenerate, or '--edit <prompt>' to modify.",
+		}
+	}
+
+	return { kind: "generate", systemPrompt: SYSTEM_PROMPT, prompt: PROMPT }
+}
+
+// ---------------------------------------------------------------------------
+// Shared: Claude execution → validation → write → build
+// ---------------------------------------------------------------------------
+
+async function generateAndWrite(
+	systemPrompt: string,
+	prompt: string,
+	extDir: string,
+	extFile: string,
+	cwd: string,
+): Promise<void> {
+	// Check claude CLI
+	const which = await Bun.$`which claude`.quiet().nothrow()
+	if (which.exitCode !== 0) {
+		console.error(
+			"claude CLI not found. Install it: https://docs.anthropic.com/en/docs/claude-code",
+		)
+		process.exit(1)
+	}
+
+	// Generate via claude
+	const result =
+		await Bun.$`claude -p --system-prompt ${systemPrompt} ${prompt}`.quiet().nothrow()
+
+	if (result.exitCode !== 0) {
+		console.error("Failed to generate extension:", result.stderr.toString())
+		process.exit(1)
+	}
+
+	const output = result.stdout.toString().trim()
+
+	// Validate
+	if (!output.startsWith("import { defineExtension }")) {
+		console.error("Error: generated output did not contain a valid extension.")
+		console.error("")
+		console.error("Raw output:")
+		console.error(output)
+		process.exit(1)
+	}
+
+	// Write
+	fs.mkdirSync(extDir, { recursive: true })
+	fs.writeFileSync(extFile, output, "utf-8")
+	console.log("Created .claude/extensions/worktree-setup/index.ts\n")
+
+	// Auto-build
+	console.log("Building extensions...\n")
+	const buildResult = await buildExtensions(cwd)
+
+	for (const err of buildResult.errors) {
+		console.error(`  ✗ ${err.extension}: ${err.error}`)
+	}
+	for (const ext of buildResult.extensions) {
+		const count = ext.registrations.length
+		console.log(`  ✓ ${ext.name} (${count} hook${count !== 1 ? "s" : ""})`)
+	}
+	console.log(`\n${buildResult.hookCount} hook(s) written to .claude/settings.local.json`)
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export default defineCommand({
+	name: "worktree",
+	description: "Generate a WorktreeCreate extension using Claude",
+	options: {
+		replace: option(z.coerce.boolean().default(false), {
+			description: "Regenerate an existing worktree-setup extension",
+		}),
+		edit: option(z.string().optional(), {
+			description: "Edit existing extension with a modification prompt",
+		}),
+	},
+	handler: async ({ flags }) => {
+		const cwd = process.cwd()
+		const extDir = path.join(cwd, ".claude", "extensions", "worktree-setup")
+		const extFile = path.join(extDir, "index.ts")
+
+		const resolution = resolvePrompts(flags, fs.existsSync(extFile))
+
+		if (resolution.kind === "error") {
+			console.error(resolution.message)
+			process.exit(1)
+		}
+
+		const label = flags.edit ? "Editing" : "Analyzing repo to generate"
+		console.log(`${label} worktree-setup extension...`)
+		return generateAndWrite(resolution.systemPrompt, resolution.prompt, extDir, extFile, cwd)
+	},
+})

--- a/src/cli/commands/preset/worktree.ts
+++ b/src/cli/commands/preset/worktree.ts
@@ -158,8 +158,7 @@ async function generateAndWrite(
 	}
 
 	// Generate via claude
-	const result =
-		await Bun.$`claude -p --system-prompt ${systemPrompt} ${prompt}`.quiet().nothrow()
+	const result = await Bun.$`claude -p --system-prompt ${systemPrompt} ${prompt}`.quiet().nothrow()
 
 	if (result.exitCode !== 0) {
 		console.error("Failed to generate extension:", result.stderr.toString())

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import activateCommand from "./commands/activate.js"
 import initCommand from "./commands/init.js"
 import listCommand from "./commands/list.js"
 import newCommand from "./commands/new.js"
+import presetCommand from "./commands/preset.js"
 import updateCommand from "./commands/update.js"
 
 const cli = await createCLI({
@@ -31,6 +32,7 @@ cli.command(initCommand)
 cli.command(newCommand)
 cli.command(listCommand)
 cli.command(activateCommand)
+cli.command(presetCommand)
 cli.command(updateCommand)
 cli.command(cleanCommand)
 

--- a/test/cli/__snapshots__/preset-worktree.test.ts.snap
+++ b/test/cli/__snapshots__/preset-worktree.test.ts.snap
@@ -1,0 +1,130 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`preset worktree — resolvePrompts new creation (no flags, extension does not exist) system prompt 1`] = `
+{
+  "kind": "generate",
+  "prompt": 
+"Generate a WorktreeCreate extension for this repo.
+
+WorktreeCreate is responsible for CREATING a git worktree and returning its absolute path.
+Claude Code uses the returned path as the working directory for the isolated session.
+If no path is returned, worktree creation FAILS.
+WorktreeRemove is NOT needed — Claude Code handles default git worktree removal automatically.
+
+Rules:
+- Start with: import { defineExtension } from "@dawkinsuke/hooks";
+- Use cc.on("WorktreeCreate", async (input) => { ... })
+- input.cwd is the project root directory
+- input.name is the worktree name/slug
+- Use Bun.$\`... 1>&2\` for shell commands (stdout is reserved for the worktree path, so redirect command output to stderr)
+- WorktreeCreate MUST return the absolute path string of the created worktree
+- Create the worktree under \`\${input.cwd}/.worktrees/\${input.name}\`
+- Be idempotent: use existsSync from "node:fs" to check if the worktree directory already exists, and if so skip creation and return the path immediately
+- Create a new branch with the same name as input.name
+- After creating the worktree, symlink any gitignored secret/config files from input.cwd
+- Install dependencies if a lock file exists (detect package manager)
+- Run codegen/build steps if applicable
+- Only include setup steps relevant to THIS repo — omit anything that doesn't apply
+- Use short comments for non-obvious lines
+- No console.log — use console.error for diagnostics (stdout is reserved for the worktree path return value)
+- If the repo needs no post-creation setup, just create the worktree and return the path
+- Do NOT add a WorktreeRemove handler — Claude Code's default git worktree removal handles cleanup automatically. A custom handler is only needed for non-git VCS (SVN, Perforce, etc.)
+
+Example output for a Node.js project:
+
+import { defineExtension } from "@dawkinsuke/hooks";
+import { existsSync } from "node:fs";
+
+export default defineExtension((cc) => {
+	cc.on("WorktreeCreate", async (input) => {
+		const root = input.cwd;
+		const name = input.name;
+		const worktreeDir = \`\${root}/.worktrees/\${name}\`;
+
+		// Reuse existing worktree if it exists
+		if (existsSync(worktreeDir)) return worktreeDir;
+
+		// Create worktree with new branch
+		await Bun.$\`git worktree add -b \${name} \${worktreeDir}\` 1>&2;
+
+		// Symlink secrets from project root
+		await Bun.$\`ln -sf "\${root}/.env" "\${worktreeDir}/.env"\` 1>&2;
+		await Bun.$\`ln -sf "\${root}/.dev.vars" "\${worktreeDir}/.dev.vars"\` 1>&2;
+
+		// Install deps and run codegen
+		await Bun.$\`cd \${worktreeDir} && npm ci && npx prisma generate\` 1>&2;
+
+		return worktreeDir;
+	});
+});
+
+Example output for a Rust project:
+
+import { defineExtension } from "@dawkinsuke/hooks";
+import { existsSync } from "node:fs";
+
+export default defineExtension((cc) => {
+	cc.on("WorktreeCreate", async (input) => {
+		const root = input.cwd;
+		const name = input.name;
+		const worktreeDir = \`\${root}/.worktrees/\${name}\`;
+
+		if (existsSync(worktreeDir)) return worktreeDir;
+
+		await Bun.$\`git worktree add -b \${name} \${worktreeDir}\` 1>&2;
+		await Bun.$\`ln -sf "\${root}/.env" "\${worktreeDir}/.env"\` 1>&2;
+		await Bun.$\`cd \${worktreeDir} && cargo fetch\` 1>&2;
+
+		return worktreeDir;
+	});
+});
+
+IMPORTANT: Output ONLY the raw TypeScript code. The very first characters of
+your response must be: import { defineExtension } — no preamble, no markdown,
+no commentary."
+,
+  "systemPrompt": 
+"You generate TypeScript extension files for hx-cli (Claude Code hooks toolkit).
+Output ONLY the TypeScript code — no markdown fences, no prose, no explanation.
+The first line of your response must be: import { defineExtension } from "@dawkinsuke/hooks";
+Do not wrap the code in \`\`\` code blocks."
+,
+}
+`;
+
+exports[`preset worktree — resolvePrompts partial modification (--edit, extension exists) system prompt and user prompt 1`] = `
+{
+  "kind": "generate",
+  "prompt": 
+"Read .claude/extensions/worktree-setup/index.ts and modify it based on:
+add pnpm support
+
+Output the complete updated extension.
+Keep all existing logic intact unless the modification explicitly changes it."
+,
+  "systemPrompt": 
+"You modify TypeScript extension files for hx-cli (Claude Code hooks toolkit).
+You will receive a modification request for an existing extension file.
+Output ONLY the modified TypeScript code — no markdown fences, no prose, no explanation.
+The first line of your response must be: import { defineExtension } from "@dawkinsuke/hooks";
+Do not wrap the code in \`\`\` code blocks."
+,
+}
+`;
+
+exports[`preset worktree — resolvePrompts error cases --edit without existing extension returns error 1`] = `
+{
+  "kind": "error",
+  "message": "No existing extension found. Run 'hx preset worktree' first.",
+}
+`;
+
+exports[`preset worktree — resolvePrompts error cases no flags with existing extension returns error 1`] = `
+{
+  "kind": "error",
+  "message": 
+"Extension "worktree-setup" already exists at .claude/extensions/worktree-setup/
+Run 'hx preset worktree --replace' to regenerate, or '--edit <prompt>' to modify."
+,
+}
+`;

--- a/test/cli/preset-worktree.test.ts
+++ b/test/cli/preset-worktree.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { resolvePrompts } from "../../src/cli/commands/preset/worktree.js"
+
+describe("preset worktree — resolvePrompts", () => {
+	// -----------------------------------------------------------------------
+	// 新規作成 (New creation)
+	// -----------------------------------------------------------------------
+	describe("new creation (no flags, extension does not exist)", () => {
+		test("system prompt", () => {
+			const result = resolvePrompts({ replace: false }, false)
+			expect(result).toMatchSnapshot()
+		})
+	})
+
+	// -----------------------------------------------------------------------
+	// 再生成 (Regeneration — --replace flag)
+	// -----------------------------------------------------------------------
+	describe("regeneration (--replace, extension exists)", () => {
+		test("system prompt is identical to new creation", () => {
+			const fresh = resolvePrompts({ replace: false }, false)
+			const replaced = resolvePrompts({ replace: true }, true)
+			expect(replaced).toEqual(fresh)
+		})
+
+		test("--replace works even when extension does not exist", () => {
+			const fresh = resolvePrompts({ replace: false }, false)
+			const replaced = resolvePrompts({ replace: true }, false)
+			expect(replaced).toEqual(fresh)
+		})
+	})
+
+	// -----------------------------------------------------------------------
+	// 部分修正 (Partial modification — --edit flag)
+	// -----------------------------------------------------------------------
+	describe("partial modification (--edit, extension exists)", () => {
+		test("system prompt and user prompt", () => {
+			const result = resolvePrompts({ replace: false, edit: "add pnpm support" }, true)
+			expect(result).toMatchSnapshot()
+		})
+	})
+
+	// -----------------------------------------------------------------------
+	// Error cases
+	// -----------------------------------------------------------------------
+	describe("error cases", () => {
+		test("--edit without existing extension returns error", () => {
+			const result = resolvePrompts({ replace: false, edit: "add pnpm support" }, false)
+			expect(result).toMatchSnapshot()
+		})
+
+		test("no flags with existing extension returns error", () => {
+			const result = resolvePrompts({ replace: false }, true)
+			expect(result).toMatchSnapshot()
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Extract `resolvePrompts()` from worktree command handler to enable unit testing of prompt selection logic
- Add snapshot tests covering new creation, regeneration (`--replace`), and partial modification (`--edit`) scenarios
- Export `SYSTEM_PROMPT`, `EDIT_SYSTEM_PROMPT`, `PROMPT` constants for test access

## Test plan
- [x] `bun test` passes (61 tests, 4 snapshots)
- [x] Typecheck passes
- [x] Lint/format passes